### PR TITLE
Remove redundant stage name in Link

### DIFF
--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -36,10 +36,6 @@ impl Link {
         reference(POSITION_OFFSET)
     }
 
-    pub fn stage() -> &'static str {
-        read_str(ptr(0x803BD23C))
-    }
-
     pub fn room() -> u8 {
         read(0x803B9230)
     }


### PR DESCRIPTION
The room number in Link is still useful because it updates in dungeons,
but the stage name isn't necessary because we already have it in
last_entrance().
